### PR TITLE
1. Modify the xcvrd.py because xcvrd entered a FATAL state.

### DIFF
--- a/0004-fix-xcvrd-entered-fatal-state.patch
+++ b/0004-fix-xcvrd-entered-fatal-state.patch
@@ -1,0 +1,54 @@
+diff --git a/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd.py b/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd.py
+index c53d2fc..4f0c47c 100644
+--- a/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd.py
++++ b/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd.py
+@@ -209,34 +209,26 @@ def post_port_sfp_info_to_db(logical_port_name, port_mapping, table, transceiver
+                 is_replaceable = _wrapper_is_replaceable(physical_port)
+                 # if cmis is supported by the module
+                 if 'cmis_rev' in port_info_dict:
+-                    fvs = swsscommon.FieldValuePairs(
++                    all_fvs_data_as_list = (
+                         [(field, str(value)) for field, value in port_info_dict.items()] +
+                         [('is_replaceable', str(is_replaceable))]
+                     )
++                    fvs = swsscommon.FieldValuePairs()
++                    for key, value in all_fvs_data_as_list:
++                        fvs.push_back((key,value))
+                 # else cmis is not supported by the module
+                 else:
+-                    fvs = swsscommon.FieldValuePairs([
+-                        ('type', port_info_dict['type']),
+-                        ('vendor_rev', port_info_dict['vendor_rev']),
+-                        ('serial', port_info_dict['serial']),
+-                        ('manufacturer', port_info_dict['manufacturer']),
+-                        ('model', port_info_dict['model']),
+-                        ('vendor_oui', port_info_dict['vendor_oui']),
+-                        ('vendor_date', port_info_dict['vendor_date']),
+-                        ('connector', port_info_dict['connector']),
+-                        ('encoding', port_info_dict['encoding']),
+-                        ('ext_identifier', port_info_dict['ext_identifier']),
+-                        ('ext_rateselect_compliance', port_info_dict['ext_rateselect_compliance']),
+-                        ('cable_type', port_info_dict['cable_type']),
+-                        ('cable_length', str(port_info_dict['cable_length'])),
+-                        ('specification_compliance', port_info_dict['specification_compliance']),
+-                        ('nominal_bit_rate', str(port_info_dict['nominal_bit_rate'])),
+-                        ('application_advertisement', port_info_dict['application_advertisement']
+-                        if 'application_advertisement' in port_info_dict else 'N/A'),
+-                        ('is_replaceable', str(is_replaceable)),
+-                        ('dom_capability', port_info_dict['dom_capability']
+-                        if 'dom_capability' in port_info_dict else 'N/A')
+-                    ])
++                    fvs = swsscommon.FieldValuePairs()
++                    fields_to_process = [
++                        'type', 'vendor_rev', 'serial', 'manufacturer', 'model',
++                        'vendor_oui', 'vendor_date', 'connector', 'encoding', 'ext_identifier',
++                        'ext_rateselect_compliance', 'cable_type', 'cable_length', 'specification_compliance',
++                        'nominal_bit_rate', 'application_advertisement', 'dom_capability'
++                    ]
++                    for key in fields_to_process:
++                        value = port_info_dict.get(key, 'N/A')
++                        fvs.push_back((key, str(value)))
++                    fvs.push_back(('is_replaceable', str(is_replaceable)))
+                 table.set(port_name, fvs)
+             else:
+                 return SFP_EEPROM_NOT_READY

--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/scripts/es1227_54ts_p2-init.sh
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/scripts/es1227_54ts_p2-init.sh
@@ -58,7 +58,7 @@ load_kernel_drivers
 
     local k
     for k in $(seq 488 4 508); do
-        echo out > /sys/class/gpio/gpio$k/direction 2>/dev/null
+        echo in > /sys/class/gpio/gpio$k/direction 2>/dev/null
     done
 
     for i in {0..2};


### PR DESCRIPTION
Fix: xcvrd daemon entered a fatal state and xcvr presence status is abnormal.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->


<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->


<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->


<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->


