### PR TITLE
[fan]fix error message "set_status_led not implemented" when remove & insert fan module

### DIFF
--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/fan.py
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/fan.py
@@ -118,12 +118,14 @@ class Fan(FanBase):
         return ''
 
     def __read_txt_file(self, file_path):
-        try:
-            with open(file_path, 'r') as fd:
-                data = fd.read()
-                return data.strip()
-        except IOError:
-            pass
+        for _ in range(3):
+            try:
+                with open(file_path, 'r') as fd:
+                    data = fd.read()
+                    return data.strip()
+            except IOError:
+                time.sleep(0.01)
+                pass
         return None
 
     def __write_txt_file(self, file_path, data):

--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/fan_drawer.py
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/fan_drawer.py
@@ -78,6 +78,12 @@ class FanDrawer(FanDrawerBase):
         """
         return self._fan_list[0].get_status_led()
 
+    def set_status_led(self, color):
+        """
+        Sets the state of the fan drawer LED
+        """
+        return self._fan_list[0].set_status_led(color)
+
     def get_position_in_parent(self):
         """
         Retrieves 1-based relative physical position in parent device.


### PR DESCRIPTION

error log:
admin@sonic:~$ show logging | grep fan
2093 Jun  3 05:32:14.838190 sonic WARNING pmon#thermalctld: Failed to set status LED for fan FAN-2, set_status_led not implemented 2093 Jun  3 05:32:14.886358 sonic WARNING pmon#thermalctld: Insufficient number of working fans warning: 1 fan is not working 2093 Jun  3 05:33:14.834687 sonic WARNING pmon#thermalctld: Failed to set status LED for fan FAN-2, set_status_led not implemented 2093 Jun  3 05:33:14.859477 sonic NOTICE pmon#thermalctld: Insufficient number of working fans warning cleared: all fans are back to 

fixed log:
admin@sonic:~$ show logging | grep fan
2093 Jun  3 02:14:14.504012 sonic INFO kernel: [    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
2093 Jun  3 02:25:17.814472 sonic WARNING pmon#thermalctld: Insufficient number of working fans warning: 1 fan is not working
2093 Jun  3 02:26:17.802666 sonic NOTICE pmon#thermalctld: Insufficient number of working fans warning cleared: all fans are back to normal
