### PR TITLE
 remove useless node (pca953x) + fix sysled firstboot + reboot cause

### DIFF
--- a/0005-es1227-54ts-board-device-tree-fixes.patch
+++ b/0005-es1227-54ts-board-device-tree-fixes.patch
@@ -1,0 +1,28 @@
+diff --git a/src/sonic-linux-kernel/patch/0016-arm64-dts-marvell-Add-Wistron-ES-1227-54TS-board.patch b/src/sonic-linux-kernel/patch/0016-arm64-dts-marvell-Add-Wistron-ES-1227-54TS-board.patch
+index 650d494..831bdcf 100644
+--- a/src/sonic-linux-kernel/patch/0016-arm64-dts-marvell-Add-Wistron-ES-1227-54TS-board.patch
++++ b/src/sonic-linux-kernel/patch/0016-arm64-dts-marvell-Add-Wistron-ES-1227-54TS-board.patch
+@@ -112,7 +112,7 @@ new file mode 100644
+ index 000000000..e3f7c4e0b
+ --- /dev/null
+ +++ b/arch/arm64/boot/dts/marvell/es1227-54ts.dtsi
+-@@ -0,0 +1,318 @@
++@@ -0,0 +1,310 @@
+ +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ +/*
+ + * Copyright (C) 2021 Marvell International Ltd.
+@@ -241,14 +241,6 @@ index 000000000..e3f7c4e0b
+ +				compatible = "ti,tmp75";
+ +				reg = <0x4b>;
+ +			};
+-+			expander0: pca953x@20 {
+-+				compatible = "nxp,pca9555";
+-+				pinctrl-names = "default";
+-+				gpio-controller;
+-+				#gpio-cells = <2>;
+-+				reg = <0x20>;
+-+				status = "okay";
+-+			};
+ +		};
+ +
+ +		i2c@1 {

--- a/0006-watchdogutil.patch
+++ b/0006-watchdogutil.patch
@@ -1,0 +1,56 @@
+diff --git a/src/sonic-utilities/watchdogutil/main.py b/src/sonic-utilities/watchdogutil/main.py
+index 84380ff1..4dbe3cd5 100644
+--- a/src/sonic-utilities/watchdogutil/main.py
++++ b/src/sonic-utilities/watchdogutil/main.py
+@@ -8,6 +8,7 @@
+ try:
+     import os
+     import sys
++    import time
+ 
+     import click
+     import sonic_platform
+@@ -107,5 +108,43 @@ def arm(seconds):
+     else:
+         click.echo("Watchdog armed for {} seconds".format(result))
+ 
++# 'daemon' subcommand
++@watchdogutil.command()
++@click.option('-s', '--seconds', default=180, type=int, help="the default timeout of HW watchdog")
++@click.option('-i', '--interval', default=2, type=int, help="the interval to arm HW watchdog")
++def daemon(seconds, interval):
++    """Run watchdog daemon"""
++    click.echo("Starting watchdog daemon...")
++
++    # Try to identify watchdog device to hold it open
++    wd_dev = None
++    for dev in ["/dev/watchdog1", "/dev/watchdog"]:
++        if os.path.exists(dev):
++            wd_dev = dev
++            break
++
++    if wd_dev:
++        try:
++            # Initial arm to set timeout via platform API
++            platform_watchdog.arm(seconds)
++            # Open and hold the device to prevent "watchdog did not stop" logs
++            fd = os.open(wd_dev, os.O_WRONLY)
++            while True:
++                os.write(fd, b'\0')
++                time.sleep(interval)
++        except Exception as e:
++            log.log_error("Daemon mode direct access failed: {}. Falling back.".format(e))
++    else:
++        log.log_warning("No watchdog device found. Falling back to platform API.")
++
++    while True:
++        try:
++            result = int(platform_watchdog.arm(seconds))
++            if result < 0:
++                log.log_error("Failed to arm Watchdog for {} seconds".format(seconds))
++        except Exception as e:
++            log.log_error("Error arming watchdog: {}".format(e))
++        time.sleep(interval)
++
+ if __name__ == '__main__':
+     watchdogutil()

--- a/platform/marvell-prestera/sonic-platform-wistron/debian/sonic-platform-es1227-54ts-p2.install
+++ b/platform/marvell-prestera/sonic-platform-wistron/debian/sonic-platform-es1227-54ts-p2.install
@@ -8,6 +8,7 @@ es1227_54ts_p2/service/es1227_54ts_p2-sysled.service etc/systemd/system
 es1227_54ts_p2/service/es1227_54ts_p2-oob-led.service etc/systemd/system
 es1227_54ts_p2/service/es1227_54ts_p2-rst_button.service etc/systemd/system
 es1227_54ts_p2/service/es1227_54ts_p2-psu-monitor.service etc/systemd/system
+es1227_54ts_p2/service/es1227_54ts_p2-watchdog.service etc/systemd/system
 es1227_54ts_p2/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/arm64-wistron_es1227_54ts_p2-r0
 es1227_54ts_p2/utils/poetool usr/local/bin
 es1227_54ts_p2/utils/es1227_54ts_p2_led.py usr/local/bin
@@ -22,3 +23,4 @@ es1227_54ts_p2/utils/poe_cfg_lldp.py usr/local/bin
 es1227_54ts_p2/utils/poe_power.sh usr/local/bin
 es1227_54ts_p2/utils/rst_button.py usr/local/bin
 es1227_54ts_p2/utils/psu_detect.py usr/local/bin
+es1227_54ts_p2/utils/es1227_54ts_p2-reboot-check usr/local/bin

--- a/platform/marvell-prestera/sonic-platform-wistron/debian/sonic-platform-es1227-54ts-p2.postinst
+++ b/platform/marvell-prestera/sonic-platform-wistron/debian/sonic-platform-es1227-54ts-p2.postinst
@@ -23,8 +23,11 @@ case "$1" in
 	depmod -a
 	sh /usr/local/bin/es1227_54ts_p2_plt_setup.sh
 	chmod a+x /usr/local/bin/es1227_54ts_p2-init.sh
+	chmod a+x /usr/local/bin/es1227_54ts_p2-reboot-check
 	systemctl enable es1227_54ts_p2-init.service
 	systemctl start es1227_54ts_p2-init.service
+	systemctl enable es1227_54ts_p2-watchdog.service
+	systemctl start es1227_54ts_p2-watchdog.service
 
     ;;
 

--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/service/es1227_54ts_p2-watchdog.service
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/service/es1227_54ts_p2-watchdog.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Platform es1227_54ts_p2 watchdog daemon
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/watchdogutil daemon -s 180 -i 5
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do docker info >/dev/null 2>&1 && exit 0; sleep 1; done; echo "docker not ready"; exit 1'
+
+Restart=always
+RestartSec=2s
+TimeoutStartSec=60
+KillMode=control-group
+KillSignal=SIGTERM
+StandardOutput=journal
+StandardError=journal
+
+ExecStopPost=/bin/sh -c '[ -x /usr/local/bin/watchdogutil ] && /usr/local/bin/watchdogutil disarm || true'
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/chassis.py
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/chassis.py
@@ -167,20 +167,35 @@ class Chassis(ChassisBase):
             is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
             to pass a description of the reboot cause.
         """
-
         reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE) if self.__is_host(
         ) else PMON_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE
-        sw_reboot_cause = self.__read_txt_file(
-            reboot_cause_path) or "Unknown"
 
+        # First boot after ONIE install: skip all detection
+        if os.path.exists("/tmp/notify_firstboot_to_platform"):
+            return (self.REBOOT_CAUSE_HARDWARE_OTHER, 'Unknown reason')
+
+        # Run es1227_54ts_p2-reboot-check first to detect thermal/watchdog cause
+        # and write result to reboot-cause.txt before we read it
+        try:
+            subprocess.run(
+                ['/usr/local/bin/es1227_54ts_p2-reboot-check'],
+                timeout=30, capture_output=True
+            )
+        except Exception:
+            pass
+
+        # Re-read the file after reboot-check has updated it
+        sw_reboot_cause = self.__read_txt_file(reboot_cause_path) or "Unknown"
+
+        # 1. Thermal cause (written by reboot-check or thermal_actions.py)
+        if sw_reboot_cause.startswith("Thermal"):
+            return (self.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER, sw_reboot_cause)
+
+        # 2. Other Software Causes (e.g., 'reboot' command)
         if sw_reboot_cause != "Unknown":
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = sw_reboot_cause
-        else:
-            reboot_cause = self.REBOOT_CAUSE_HARDWARE_OTHER
-            description = 'Unknown reason'
+            return (self.REBOOT_CAUSE_NON_HARDWARE, sw_reboot_cause)
 
-        return (reboot_cause, description)
+        return (self.REBOOT_CAUSE_HARDWARE_OTHER, 'Watchdog or Unknown reason')
 
     def _get_sku_name(self):
         if self.__is_host():

--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/thermal_actions.py
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/thermal_actions.py
@@ -103,8 +103,11 @@ class SetFanSpeedAction(ThermalPolicyActionBase):
 
     @classmethod
     def power_down(cls):
-        chassis = cls().get_chassis()
-        chassis.power_down()
+        # Directly power off the DUT using systemctl, fallback to poweroff command
+        import os
+        # systemctl returns 0 on success; if it fails, try plain poweroff
+        if os.system('systemctl poweroff') != 0:
+            os.system('poweroff')
 
     @classmethod
     def get_temp(cls, thermal_info_dict):
@@ -170,7 +173,31 @@ class SwitchPolicyAction(ThermalPolicyActionBase):
                 sonic_logger.log_warning(
                     "Temp is over high critical threshold, system shutdown {} temperature is {}".format(key, temp_info[key]))
             import os
+            from sonic_platform.chassis import HOST_REBOOT_CAUSE_PATH, PMON_REBOOT_CAUSE_PATH, REBOOT_CAUSE_FILE
+
+            # Determine which components triggered the shutdown
+            components = set()
+            for key in temp_info.keys():
+                ukey = key.upper()
+                if 'PSU' in ukey: components.add('PSU')
+                elif 'CPU' in ukey: components.add('CPU')
+                elif 'ASIC' in ukey: components.add('ASIC')
+                elif 'DIMM' in ukey: components.add('DIMM')
+                else: components.add(key.split()[0]) # Fallback to first word of sensor name
+
+            # Write to the official reboot-cause file (for show reboot-cause history)
+            reboot_msg = "Thermal"
+            if components:
+                reboot_msg += " - " + "/".join(sorted(list(components)))
+
+            host_path = HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE
+            pmon_path = PMON_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE
+            os.system(f"sudo sh -c 'echo \"{reboot_msg}\" > {host_path}'")
+            os.system(f"sudo sh -c 'echo \"{reboot_msg}\" > {pmon_path}'")
+
             os.system('sync')
+            # Stop watchdog service to avoid overwriting reboot-cause
+            os.system('systemctl stop es1227_54ts_p2-watchdog')
             SetFanSpeedAction.power_down()
         # import os
         # os.system('reboot')

--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/utils/es1227_54ts_p2-reboot-check
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/utils/es1227_54ts_p2-reboot-check
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
+THERMAL_TIMESTAMP_FILE="/var/log/thermal_shutdown_timestamp" # Assuming a file to store thermal shutdown timestamp
+THERMAL_TIMESTAMP_LIMIT_SECONDS=300 # 5 minutes
+
+# Thermal reboot check
+THERMAL_REBOOT_CHECK() {
+    local is_thermal_reboot=false
+    local limit_seconds=3600 # 1 hour threshold for fresh boot
+    local syslog_file="/var/log/syslog"
+
+    # 1. Get current and previous reboot timestamps from history
+    local history_records=$(show reboot-cause history | grep -E '[0-9]{4}_[0-9]{2}' | awk '{print $1}' | head -n 2)
+    local current_rb_name=$(echo "$history_records" | sed -n '1p')
+    local previous_rb_name=$(echo "$history_records" | sed -n '2p')
+
+    if [[ -n "$current_rb_name" ]]; then
+        format_name_to_date() { echo "$1" | sed 's/_/-/1; s/_/-/1; s/_/ /1; s/_/:/1; s/_/:/1'; }
+        local current_rb_ts=$(date -d "$(format_name_to_date "$current_rb_name")" +%s)
+        local now_ts=$(date +%s)
+        local boot_diff=$((now_ts - current_rb_ts))
+
+        # Priority 1: Syslog Correlation
+        if [[ "$boot_diff" -ge -60 && "$boot_diff" -le "$limit_seconds" ]]; then
+            local syslog_line=$(sudo grep -a "Temp is over high critical threshold" "$syslog_file" | tail -n 1)
+
+            if [[ -n "$syslog_line" ]]; then
+                local syslog_time_str=$(echo "$syslog_line" | awk '{print $1" "$2" "$3}' | cut -d'.' -f1)
+                local rb_year=$(echo "$current_rb_name" | cut -d'_' -f1)
+                # Try format: "Feb 2 00:45:05 2025"
+                local trigger_ts=$(date -d "$syslog_time_str $rb_year" +%s)
+
+                if [[ $trigger_ts -gt $current_rb_ts ]]; then
+                    trigger_ts=$(date -d "$syslog_time_str $((rb_year - 1))" +%s)
+                fi
+
+                local is_after_prev=true
+                if [[ -n "$previous_rb_name" ]]; then
+                    local previous_rb_ts=$(date -d "$(format_name_to_date "$previous_rb_name")" +%s)
+                    if [[ $trigger_ts -le $previous_rb_ts ]]; then is_after_prev=false; fi
+                fi
+
+                if $is_after_prev && [[ $trigger_ts -lt $current_rb_ts ]]; then
+                    local sensor_info=$(echo "$syslog_line" | sed 's/.*system shutdown //')
+                    # Extract the first word of the sensor name and convert to uppercase
+                    thermal_detail=$(echo "$sensor_info" | awk '{print $1}' | tr 'a-z' 'A-Z')
+                    echo "[thermal-check] Verified via Syslog: $syslog_time_str"
+                    echo "[thermal-check] Details: $sensor_info"
+                    is_thermal_reboot=true
+                fi
+            fi
+        fi
+    fi
+
+    # Priority 2: Persistent file content
+    if ! $is_thermal_reboot; then
+        if [[ -f "$REBOOT_CAUSE_FILE" ]] && grep -qi "Thermal" "$REBOOT_CAUSE_FILE"; then
+            echo "[thermal-check] Verified via persistent file content."
+            is_thermal_reboot=true
+        fi
+    fi
+
+    if $is_thermal_reboot; then
+        local final_cause="Thermal"
+        if [[ -n "$thermal_detail" ]]; then
+            final_cause="Thermal - $thermal_detail"
+        else
+            # If validated via file content, try to preserve the existing detail
+            local current_file_msg=$(cat "$REBOOT_CAUSE_FILE" 2>/dev/null)
+            if [[ "$current_file_msg" =~ [Tt]hermal ]]; then
+                final_cause="$current_file_msg"
+            fi
+        fi
+
+        # Force uppercase "T" for compatibility with platform API
+        [[ "$final_cause" == "thermal" ]] && final_cause="Thermal"
+
+        echo "$final_cause" > $REBOOT_CAUSE_FILE
+        echo "[reboot-cause.txt] : $(cat $REBOOT_CAUSE_FILE)"
+        echo "reboot cause by thermal"
+
+        # Only clear the cause if we've been up for a while to avoid racing with history service
+        # or if forced by user
+        local uptime_s=$(cat /proc/uptime | awk '{print int($1)}')
+        if [[ $uptime_s -gt 240 || -n "$FORCE_CLEAR" ]]; then
+            #echo "Unknown" > "$REBOOT_CAUSE_FILE"
+            echo "[reboot-check] Cause file reset to Unknown (Uptime: $uptime_s s)."
+        else
+            echo "[reboot-check] Skipping cause reset (Uptime too short: $uptime_s s) to allow history logging."
+        fi
+        return 0
+    fi
+    return 1
+}
+
+# Main execution
+FIRST_BOOT_FILE="/tmp/notify_firstboot_to_platform"
+if [[ -f "$FIRST_BOOT_FILE" ]]; then
+    echo "[reboot-check] First boot after ONIE install detected, skipping reboot cause check."
+    exit 0
+fi
+
+THERMAL_REBOOT_CHECK 

--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/utils/sysled_health.py
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/utils/sysled_health.py
@@ -1,3 +1,4 @@
+import os
 import sonic_platform
 import time
 
@@ -5,6 +6,8 @@ def main():
 
     pl=sonic_platform.platform.Platform()
     cha=pl.get_chassis()
+    
+    os.system("echo 1 > /sys/bus/i2c/devices/0-0033/sys_led")
     # Loop forever:
     while True:
         time.sleep(5)


### PR DESCRIPTION
1. [IO expander] remove useless node (pca953x)
2. [led] fix sysled firstboot

- when firstboot
- original :red
- fixed :green
3. [watchdog]improve thermal and watchdog reboot cause detection 
