### PR TITLE
[lldp/gnmi] Fix docker containers startup failure by passing missing environment variables

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -761,6 +761,7 @@ start() {
         --env "CONTAINER_NAME"=$DOCKERNAME \
         --env "SYSLOG_TARGET_IP"=$SYSLOG_TARGET_IP \
         --env "PLATFORM"=$PLATFORM \
+        --env "IMAGE_VERSION"=$SONIC_VERSION \
         --name=$DOCKERNAME \
 {%- if docker_container_name == "gbsyncd" %}
         -v /var/run/docker-syncd$DEV:/var/run/sswsyncd \


### PR DESCRIPTION

error log :
show logging
    2025 Jun 26 15:00:30.259808 sonic INFO gnmi#supervisord: start container_startup.py: error: argument -v/--version: expected one argument
    2025 Jun 26 15:00:35.223841 sonic INFO lldp#supervisord: start container_startup.py: error: argument -v/--version: expected one argument
    2025 Jun 26 14:58:51.723645 sonic INFO dockerd[810]: level=error msg="Error setting up exec comman
d in container lldp: Container is not running"

