### PR TITLE
[pmon] Fix container startup failure when removable devices are detached

### DIFF
--- a/0008-pmon-usb-mount-fix.patch
+++ b/0008-pmon-usb-mount-fix.patch
@@ -1,0 +1,17 @@
+diff --git a/files/build_templates/docker_image_ctl.j2 b/files/build_templates/docker_image_ctl.j2
+index f9fcfc93e..ea38191c5 100644
+--- a/files/build_templates/docker_image_ctl.j2
++++ b/files/build_templates/docker_image_ctl.j2
+@@ -716,11 +716,9 @@ start() {
+     -v /usr/share/sonic/firmware:/usr/share/sonic/firmware:rw \
+     $(if [ -e "/dev/i2c-0" ]; then echo "--device=/dev/i2c-0:/dev/i2c-0"; fi) \
+     $(if [ -e "/dev/ipmi0" ]; then echo "--device=/dev/ipmi0:/dev/ipmi0"; fi) \
+-    $(if [ -e "/dev/sda" ]; then echo "--device=/dev/sda:/dev/sda"; fi) \
+-    $(if [ -e "/dev/sdb" ]; then echo "--device=/dev/sdb:/dev/sdb"; fi) \
+     $(if [ -e "/dev/watchdog" ]; then echo "--device=/dev/watchdog:/dev/watchdog"; fi) \
+     $(for watchdog in /sys/class/watchdog/*; do if [ -d "$watchdog" ]; then device_name=$(basename "$watchdog"); dev_file="/dev/$device_name"; if [ -e "$dev_file" ]; then echo "--device=$dev_file:$dev_file"; fi; fi; done) \
+-    $(for blockdev in /sys/block/*; do if [ -d "$blockdev" ]; then device_name=$(basename "$blockdev"); if [[ "$device_name" =~ ^(sd[a-z]+|nvme[0-9]+n[0-9]+)$ ]] && [[ ! "$device_name" =~ (boot|loop) ]]; then dev_file="/dev/$device_name"; if [ -e "$dev_file" ]; then echo "--device=$dev_file:$dev_file"; fi; fi; fi; done) \
++    $(for blockdev in /sys/block/*; do if [ -d "$blockdev" ]; then device_name=$(basename "$blockdev"); if [[ "$device_name" =~ ^(sd[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+)$ ]] && [[ ! "$device_name" =~ (boot|loop) ]] && [[ "$(cat $blockdev/removable 2>/dev/null)" == "0" ]]; then dev_file="/dev/$device_name"; if [ -e "$dev_file" ]; then echo "--device=$dev_file:$dev_file"; fi; fi; fi; done) \
+     $(for dev_file in /dev/nvme*; do if [ -e "$dev_file" ]; then echo "--device=$dev_file:$dev_file"; fi; done) \
+ {%- endif %}
+ {%- if docker_container_name == "swss" %}


### PR DESCRIPTION
The container template was hardcoded to map /dev/sda and /dev/sdb. If the system was installed or initialized with a USB drive attached (often assigned as /dev/sda), the container would keep this dependency. Once the USB was removed, subsequent container restarts would fail with error 128 (no such file or directory) because Docker could not find the device to map. This commit improves the device mapping logic in docker_image_ctl.j2:
- Remove static mapping for /dev/sda and /dev/sdb.
- Enhance dynamic block device discovery to include mmcblk* devices (required for ES1227-series using eMMC).
- Filter devices by the 'removable' attribute. Only fixed storage (removable=0) will be mapped into the container. This ensures the container remains stable regardless of transient USB device presence.

patch -p1  <0008-pmon-usb-mount-fix.patch

