### PR TITLE
[kdump] Fix kdump functionality and compatibility

### DIFF
--- a/0009-kdump_host_services.patch
+++ b/0009-kdump_host_services.patch
@@ -1,0 +1,74 @@
+diff --git a/src/sonic-host-services/scripts/hostcfgd b/src/sonic-host-services/scripts/hostcfgd
+index 771b70e..2e58936 100644
+--- a/src/sonic-host-services/scripts/hostcfgd
++++ b/src/sonic-host-services/scripts/hostcfgd
+@@ -1228,43 +1228,37 @@ class KdumpCfg(object):
+             return
+         if key == "config":
+             # Admin mode
+-            kdump_enabled = self.kdump_defaults["enabled"]
+-            if data.get("enabled") is not None:
+-                kdump_enabled = data.get("enabled")
+-            if kdump_enabled.lower() == "true":
+-                enabled = True
+-            else:
+-                enabled = False
+-            if enabled:
+-                run_cmd(["sonic-kdump-config", "--enable"])
+-            else:
+-                run_cmd(["sonic-kdump-config", "--disable"])
++            kdump_enabled = data.get("enabled", self.kdump_defaults["enabled"])
++            if kdump_enabled is not None:
++                if kdump_enabled.lower() == "true":
++                    run_cmd(["sonic-kdump-config", "--enable"])
++                else:
++                    run_cmd(["sonic-kdump-config", "--disable"])
+ 
+             # Memory configuration
+-            memory = self.kdump_defaults["memory"]
+-            if data.get("memory") is not None:
+-                memory = data.get("memory")
+-            run_cmd(["sonic-kdump-config", "--memory", memory])
++            memory = data.get("memory", self.kdump_defaults["memory"])
++            if memory is not None:
++                run_cmd(["sonic-kdump-config", "--memory", str(memory)])
+ 
+             # Num dumps
+-            num_dumps = self.kdump_defaults["num_dumps"]
+-            if data.get("num_dumps") is not None:
+-                num_dumps = data.get("num_dumps")
+-            run_cmd(["sonic-kdump-config", "--num_dumps", num_dumps])
+-
+-            # Remote option
+-            remote = self.kdump_defaults["remote"]
+-            if data.get("remote") is not None:
+-                remote = data.get("remote")
+-            run_cmd(["sonic-kdump-config", "--remote", remote])
+-
+-            ssh_string = self.kdump_defaults["ssh_string"]
+-            if data.get("ssh_string") is not None:
+-                    run_cmd(["sonic-kdump-config", "--ssh_string", ssh_string])
++            num_dumps = data.get("num_dumps", self.kdump_defaults["num_dumps"])
++            if num_dumps is not None:
++                run_cmd(["sonic-kdump-config", "--num_dumps", str(num_dumps)])
++
++            # Remote option (maintain compatibility with boolean strings)
++            remote = data.get("remote", self.kdump_defaults["remote"])
++            if remote is not None:
++                run_cmd(["sonic-kdump-config", "--remote", str(remote)])
++
++            # ssh_string
++            ssh_string = data.get("ssh_string", self.kdump_defaults["ssh_string"])
++            if ssh_string is not None:
++                run_cmd(["sonic-kdump-config", "--ssh_string", str(ssh_string)])
++
+             # ssh_path
+-            ssh_path= self.kdump_defaults["ssh_path"]
+-            if data.get("ssh_path") is not None:
+-                    run_cmd(["sonic-kdump-config", "--ssh_path", ssh_path])
++            ssh_path = data.get("ssh_path", self.kdump_defaults["ssh_path"])
++            if ssh_path is not None:
++                run_cmd(["sonic-kdump-config", "--ssh_path", str(ssh_path)])
+ 
+ class NtpCfg(object):
+     """

--- a/0009-kdump_utilities.patch
+++ b/0009-kdump_utilities.patch
@@ -1,0 +1,216 @@
+diff --git a/src/sonic-utilities/scripts/sonic-kdump-config b/src/sonic-utilities/scripts/sonic-kdump-config
+index d7304758..f8c8fbff 100755
+--- a/src/sonic-utilities/scripts/sonic-kdump-config
++++ b/src/sonic-utilities/scripts/sonic-kdump-config
+@@ -24,6 +24,7 @@ import shlex
+ import sys
+ import syslog
+ import subprocess
++import re
+ 
+ from swsscommon.swsscommon import ConfigDBConnector
+ from sonic_installer.bootloader import get_bootloader
+@@ -371,7 +372,7 @@ def get_kdump_ssh_path():
+ #
+ #  @return The integer value X from USE_KDUMP=X in /etc/default/kdump-tools
+ def read_use_kdump():
+-    (rc, lines, err_str) = run_command("grep 'USE_KDUMP=.*' %s | cut -d = -f 2" % kdump_cfg, use_shell=False);
++    (rc, lines, err_str) = run_command("grep 'USE_KDUMP=.*' %s | cut -d = -f 2" % kdump_cfg, use_shell=True);
+     if rc == 0 and type(lines) == list and len(lines) >= 1:
+         try:
+             return int(lines[0])
+@@ -405,7 +406,7 @@ def write_use_kdump(use_kdump):
+ #
+ #  @return The integer value X from KDUMP_NUM_DUMPS=X in /etc/default/kdump-tools
+ def read_num_dumps():
+-    (rc, lines, err_str) = run_command("grep '#*KDUMP_NUM_DUMPS=.*' %s | cut -d = -f 2" % kdump_cfg, use_shell=False);
++    (rc, lines, err_str) = run_command("grep '#*KDUMP_NUM_DUMPS=.*' %s | cut -d = -f 2" % kdump_cfg, use_shell=True);
+     if rc == 0 and type(lines) == list and len(lines) >= 1:
+         try:
+             return int(lines[0])
+@@ -448,7 +449,7 @@ def write_kdump_remote():
+         print("SSH and SSH_KEY commented out for local configuration.")
+ 
+ def read_ssh_string():
+-    (rc, lines, err_str) = run_command("grep '#*SSH=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=False)
++    (rc, lines, err_str) = run_command("grep '#*SSH=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=True)
+     if rc == 0 and type(lines) == list and len(lines) >= 1:
+         try:
+             return lines[0].strip()  # Return the SSH string (e.g., user@ip_address)
+@@ -479,7 +480,7 @@ def write_ssh_string(ssh_string):
+         sys.exit(1)
+ 
+ def read_ssh_path():
+-    (rc, lines, err_str) = run_command("grep '#*SSH_KEY=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=False)
++    (rc, lines, err_str) = run_command("grep '#*SSH_KEY=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=True)
+     if rc == 0 and type(lines) == list and len(lines) >= 1:
+         try:
+             ssh_path = lines[0].strip()
+@@ -496,7 +497,7 @@ def read_ssh_path():
+ def write_ssh_path(ssh_path):
+     cmd = "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"%s\"/' %s" % (ssh_path, kdump_cfg)
+ 
+-    (rc, lines, err_str) = run_command(cmd, use_shell=False)  # Make sure to set use_shell=True
++    (rc, lines, err_str) = run_command(cmd, use_shell=True)
+     if rc == 0 and type(lines) == list and len(lines) == 0:
+         ssh_path_in_cfg = read_ssh_path()
+         if ssh_path_in_cfg != ssh_path:
+@@ -563,7 +564,8 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file,
+     if remote:
+         if verbose:
+             print(f"Configuring remote crash dump to {ssh_string} using SSH keys from {ssh_path}")
+-
++        run_command("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=False)
++        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
+         # Set up SSH connection with ssh_string and ssh_path
+         (rc, lines, err_str) = run_command(f"/usr/sbin/kdump-config set-remote {ssh_string} {ssh_path}", use_shell=False)
+         if rc != 0:
+@@ -572,6 +574,8 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file,
+     else:
+         if verbose:
+             print("Local crash dump configuration enabled")
++        run_command("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=False)
++        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
+ 
+     # Reload kdump configuration if needed
+     if crash_kernel_in_cmdline is not None:
+@@ -583,6 +587,100 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file,
+     return changed
+ 
+ 
++def kdump_enable_uboot(verbose, kdump_enabled, memory, num_dumps, image, remote, ssh_string, ssh_path):
++    if verbose:
++        print("Enabling kdump for U-Boot platform")
++
++    (rc, lines, err_str) = run_command("/usr/bin/fw_printenv -n linuxargs", use_shell=False)
++    if rc != 0:
++        print_err("Error: Unable to read linuxargs from U-Boot environment")
++        return False
++
++    linuxargs = lines[0].strip() if lines else ""
++
++    # Check if crashkernel is already set in /proc/cmdline
++    crash_kernel_in_cmdline = search_for_crash_kernel_in_cmdline()
++
++    # Check if crashkernel is already set in linuxargs
++    expected_str = 'crashkernel='
++    p = linuxargs.find(expected_str)
++
++    changed = False
++    if p == -1:
++        new_linuxargs = (linuxargs + " crashkernel=%s" % memory).strip()
++        changed = True
++        if verbose:
++            print("Added crashkernel=%s to linuxargs" % memory)
++    else:
++        # Extract current crashkernel
++        tail = linuxargs[p:]
++        next_space = tail.find(" ")
++        current_val = tail[:next_space] if next_space != -1 else tail
++        if current_val != "crashkernel=%s" % memory:
++            new_linuxargs = linuxargs.replace(current_val, "crashkernel=%s" % memory)
++            changed = True
++            if verbose:
++                print("Updated crashkernel to %s in linuxargs" % memory)
++        else:
++            new_linuxargs = linuxargs
++            if verbose:
++                print("crashkernel is already set correctly in linuxargs")
++
++    if changed:
++        (rc, _, err_str) = run_command(['/usr/bin/fw_setenv', 'linuxargs', new_linuxargs], use_shell=False)
++        if rc != 0:
++            print_err("Error: Unable to update linuxargs in U-Boot environment")
++            return False
++
++    # Enable kdump
++    write_use_kdump(1)
++
++    # New functionality: Handle remote crash dump if "remote" is enabled
++    if remote:
++        if verbose:
++            print(f"Configuring remote crash dump to {ssh_string} using SSH keys from {ssh_path}")
++        run_command("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=False)
++        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
++        # Set up SSH connection with ssh_string and ssh_path
++        (rc, lines, err_str) = run_command(f"/usr/sbin/kdump-config set-remote {ssh_string} {ssh_path}", use_shell=False)
++        if rc != 0:
++            print_err("Error: Unable to set remote crash dump configuration", err_str)
++            sys.exit(1)
++    else:
++        if verbose:
++            print("Local crash dump configuration enabled")
++        run_command("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=False)
++        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
++
++    # Reload kdump configuration if needed
++    if crash_kernel_in_cmdline is not None:
++        (rc, lines, err_str) = run_command("/usr/sbin/kdump-config load", use_shell=False)
++
++    return changed
++
++
++def kdump_disable_uboot(verbose):
++    write_use_kdump(0)
++    (rc, lines, err_str) = run_command("/usr/bin/fw_printenv -n linuxargs", use_shell=False)
++    if rc != 0:
++        print_err("Error: Unable to read linuxargs from U-Boot environment")
++        return False
++
++    linuxargs = lines[0].strip() if lines else ""
++    if 'crashkernel=' in linuxargs:
++        # Remove crashkernel=...
++        new_linuxargs = re.sub(r'crashkernel=[^\s]+', '', linuxargs).strip()
++        new_linuxargs = re.sub(r'\s+', ' ', new_linuxargs)
++        if verbose:
++            print("Removing crashkernel from linuxargs")
++        (rc, _, err_str) = run_command(['/usr/bin/fw_setenv', 'linuxargs', new_linuxargs], use_shell=False)
++        if rc != 0:
++            print_err("Error: Unable to update linuxargs in U-Boot environment")
++            return False
++        return True
++    return False
++
++
+ ## Read kdump configuration saved in the startup configuration file
+ #
+ #  @param    config_param If True, the function will display a few additional information.
+@@ -626,6 +724,8 @@ def cmd_kdump_enable(verbose, image):
+     elif open(machine_cfg, 'r').read().find('aboot_platform') >= 0:
+         aboot_cfg = aboot_cfg_template % image
+         return kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, aboot_cfg, remote, ssh_string, ssh_path)
++    elif get_bootloader().NAME == 'uboot':
++        return kdump_enable_uboot(verbose, kdump_enabled, memory, num_dumps, image, remote, ssh_string, ssh_path)
+     else:
+         print("Feature not supported on this platform")
+         return False
+@@ -708,6 +808,8 @@ def cmd_kdump_disable(verbose):
+     elif open(machine_cfg, 'r').read().find('aboot_platform') >= 0:
+         aboot_cfg = aboot_cfg_template % image
+         return kdump_disable(verbose, image, aboot_cfg)
++    elif get_bootloader().NAME == 'uboot':
++        return kdump_disable_uboot(verbose)
+     else:
+         print("Feature not supported on this platform")
+         return False
+@@ -826,9 +928,9 @@ def main():
+     parser.add_argument('--num_dumps', nargs='?', type=int, action='store', default=False,
+         help='Maximum number of kernel dump files stored')
+ 
+-    parser.add_argument('--remote', action='store_true', default=False,
++    parser.add_argument('--remote', nargs='?', type=str, action='store', default=False,
+                 help='Enable remote kdump via SSH')
+-    
++
+     parser.add_argument('--ssh_string', nargs='?', type=str, action='store', default=False,
+             help='ssh_string for remote kdump')
+ 
+@@ -873,7 +975,7 @@ def main():
+         elif options.ssh_string:
+             cmd_kdump_ssh_string(options.verbose, options.ssh_string)
+         elif options.ssh_path:
+-            cmd_kdump_ssh_path(options.verbos, options.ssh_path)
++            cmd_kdump_ssh_path(options.verbose, options.ssh_path)
+         elif options.num_dumps != False:
+             cmd_kdump_num_dumps(options.verbose, options.num_dumps)
+         elif options.dump_db:


### PR DESCRIPTION
# Why I did it:
## Kdump was non-functional on Wistron ES-1227-54TS-P2 platform due to:
1. Hardcoded x86/Grub logic in sonic-kdump-config which failed on U-Boot.
2. hostcfgd service crash (TypeError) when KDUMP SSH parameters are missing in ConfigDB.
3. kdump-tools failing local dump capture when SSH remains enabled in configuration. How I did it:
1. Modified sonic-kdump-config:
   - Added U-Boot environment support via fw_printenv/fw_setenv on 'linuxargs' variable.
   - Implemented automatic comment/uncomment of SSH/SSH_KEY in /etc/default/kdump-tools when switching between local and remote dump modes.
   - Restored argument-based parser compatibility to satisfy hostcfgd unit tests.
2. Modified hostcfgd:
   - Added defensive checks to handle None values from ConfigDB with default fallbacks.
   - Ensured all parameters passed to sonic-kdump-config are cast to strings.
3. Included generated patches:
   - 0009-kdump_utilities.patch
   - 0009-kdump_host_services.patch command : patch -p1 <0009-kdump_utilities.patch command : patch -p1 <0009-kdump_host_services.patch How to verify it:
1. config kdump enable
2. config save && reboot
3. Validated fw_printenv linuxargs contains 'crashkernel'
4. echo c > /proc/sysrq-trigger
5. System rebooted into crash kernel and successfully saved vmcore to /var/crash/

# command :
## enable
sudo config kdump enable
sudo config kdump memory "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M" # save config
sudo config save -y
sudo reboot
## check uboot env (crashkernel=...)
fw_printenv linuxargs
## check kdump status
show kdump config
result Kdump administrative mode: Enabled
Kdump operational mode: Ready
Kdump memory reservation: 0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M # trigger kernel panic
echo 1 | sudo tee /proc/sys/kernel/sysrq
echo c | sudo tee /proc/sysrq-trigger
## check log
show kdump files


