### PR TITLE
[RTC] update RTC model "ds1388" to "ds1338"

### DIFF
--- a/0005-es1227-54ts-board-device-tree-fixes.patch
+++ b/0005-es1227-54ts-board-device-tree-fixes.patch
@@ -26,3 +26,14 @@ index 650d494..831bdcf 100644
  +		};
  +
  +		i2c@1 {
+@@ -274,8 +266,8 @@ index 000000000..e3f7c4e0b
+ +			#size-cells = <0>;
+ +			reg = <4>;
+ +
+-+			rtc0:rtc-ds1388@68 {
+-+				compatible = "dallas,ds1388";
+++			rtc0:rtc-ds1338@68 {
+++				compatible = "dallas,ds1338";
+ +				/* PDF P13 : 1101 000 R/nW , 0x68+ R/nW */
+ +				reg = <0x68>;
+ +			};


### PR DESCRIPTION
chronyd daemon sync OS time from pool.ntp.org
Before update:
root@sonic:/home/admin# cat /proc/device-tree/cp0/config-space@f2000000/i2c@701000/i2c-switch1@77/i2c@4/rtc-ds1338@68/compatible cat: /proc/device-tree/cp0/config-space@f2000000/i2c@701000/i2c-switch1@77/i2c@4/rtc-ds1338@68/compatible: No such file or directory root@sonic:/home/admin# date
Tue Jun  4 04:38:34 AM UTC 2002

After fix :
root@sonic:/home/admin# cat /proc/device-tree/cp0/config-space@f2000000/i2c@701000/i2c-switch1@77/i2c@4/rtc-ds1338@68/compatible dallas,ds1338
root@sonic:/home/admin# date
Wed Apr  8 03:20:16 PM UTC 2026

