### PR TITLE
Fix pmon#xcvrd error on SFP removal by implementing clear_eeprom_buffer in sfp.py

### DIFF
--- a/platform/marvell-teralynx/sonic-platform-modules-wistron/6512-32r/sonic_platform/sfp.py
+++ b/platform/marvell-teralynx/sonic-platform-modules-wistron/6512-32r/sonic_platform/sfp.py
@@ -100,6 +100,9 @@ class Sfp(SfpOptoeBase):
         self.port_to_grid_mapping = {}
         self.port_to_freq_mapping = {}
         self.port_to_outp_mapping = {}
+        self.port_to_eeprom2f_mapping = {}
+        self.port_to_eeprom34_mapping = {}
+        self.port_to_eeprom35_mapping = {}
         for x in range(self.PORT_START, self.PORT_END + 1):
             self.port_to_eeprom1_mapping[x] = eeprom_path_prefix + self.port_to_i2c_mapping[x] + '/eeprom1'
             self.port_to_eeprom2_mapping[x] = eeprom_path_prefix + self.port_to_i2c_mapping[x] + '/eeprom2'
@@ -110,11 +113,79 @@ class Sfp(SfpOptoeBase):
             self.port_to_grid_mapping[x] = eeprom_path_prefix + self.port_to_i2c_mapping[x] + '/grid'
             self.port_to_freq_mapping[x] = eeprom_path_prefix + self.port_to_i2c_mapping[x] + '/freq'
             self.port_to_outp_mapping[x] = eeprom_path_prefix + self.port_to_i2c_mapping[x] + '/output_power'
+            self.port_to_eeprom2f_mapping[x] = eeprom_path_prefix + self.port_to_i2c_mapping[x] + '/eeprom_pg2f'
+            self.port_to_eeprom34_mapping[x] = eeprom_path_prefix + self.port_to_i2c_mapping[x] + '/eeprom_pg34'
+            self.port_to_eeprom35_mapping[x] = eeprom_path_prefix + self.port_to_i2c_mapping[x] + '/eeprom_pg35'
 
         self.reinit()
 
     def reinit(self):
         self._detect_sfp_type(self.sfp_type)
+
+    def clear_eeprom_buffer(self):
+        """
+        Called on SFP removal. Writes blank/zero data to all sysfs EEPROM
+        buffer files to reset the kernel driver's cached EEPROM state.
+        """
+        for i in range(0, 5):
+            if i == 0:
+                sysfs_sfp_i2c_client_eeprom_path = self.port_to_eeprom1_mapping[self.index]
+            elif i == 1:
+                sysfs_sfp_i2c_client_eeprom_path = self.port_to_eeprom2_mapping[self.index]
+            elif i == 2:
+                sysfs_sfp_i2c_client_eeprom_path = self.port_to_eeprom3_mapping[self.index]
+            elif i == 3:
+                sysfs_sfp_i2c_client_eeprom_path = self.port_to_eeprom4_mapping[self.index]
+            else:
+                sysfs_sfp_i2c_client_eeprom_path = self.port_to_eeprom12_mapping[self.index]
+            try:
+                with open(sysfs_sfp_i2c_client_eeprom_path, 'w') as fd:
+                    fd.write(" ")
+                    fd.close()
+            except IOError:
+                pass
+        try:
+            with open(self.port_to_grid_mapping[self.index], "w") as fd:
+                fd.write("0")
+                fd.close()
+        except IOError:
+            pass
+        try:
+            with open(self.port_to_freq_mapping[self.index], "w") as fd:
+                fd.write("0")
+                fd.close()
+        except IOError:
+            pass
+        try:
+            with open(self.port_to_outp_mapping[self.index], "w") as fd:
+                fd.write("0")
+                fd.close()
+        except IOError:
+            pass
+        try:
+            with open(self.port_to_power_mode_mapping[self.index], "w") as fd:
+                fd.write("0")
+                fd.close()
+        except IOError:
+            pass
+        try:
+            with open(self.port_to_eeprom2f_mapping[self.index], 'w') as fd:
+                fd.write(" ")
+                fd.close()
+        except IOError:
+            pass
+        try:
+            with open(self.port_to_eeprom34_mapping[self.index], 'w') as fd:
+                fd.write(" ")
+                fd.close()
+        except IOError:
+            pass
+        try:
+            with open(self.port_to_eeprom35_mapping[self.index], 'w') as fd:
+                fd.write(" ")
+                fd.close()
+        except IOError:
+            pass
 
     def _detect_sfp_type(self, sfp_type):
         eeprom_raw = []


### PR DESCRIPTION
## Description
This PR resolves a critical stability issue where the xcvrd daemon crashes upon the physical removal of a transceiver. The crash was caused by an `AttributeError` when the Platform API attempted to invoke a missing method in the sfp.py module.

## Problem
When a transceiver is unplugged, `chassis.py` triggers a cleanup routine: self._clear_sfp_eeprom_buffer(port) -> sfp.clear_eeprom_buffer()

Because the `Sfp` class in this branch lacked the `clear_eeprom_buffer`method, the daemon would raise the following exception and terminate: 
```
AttributeError: 'Sfp' object has no attribute 'clear_eeprom_buffer'
```
## Solution
Implemented the missing buffer cleanup logic in `sfp.py`. 
Key Changes in `sfp.py`:

Implemented `clear_eeprom_buffer(self)`:
- Added the method to write blank data/null characters to the kernel sysfs EEPROM attributes. This ensures that the kernel driver's I2C cache is flushed correctly upon removal.
- Added missing sysfs mappings: Initialized and mapped the following dictionary attributes required for the cleanup logic:
```
self.port_to_eeprom2f_mapping
self.port_to_eeprom34_mapping
self.port_to_eeprom35_mapping
```
## Testing Performed

#### Manual Hardware Verification:
-  Deployed the fixed `sfp.py` into the pmon container on a Wistron 6512-32R switch. Verified via syslog that xcvrd remains stable and successfully processes plug-out events without crashing. 

#### CLI Data Accuracy:
- Verified that the command `show interfaces transceiver eeprom` produces the correct, decoded information for all inserted modules.

#### Kernel Buffer Flush Test:
1. Monitored the physical system file /sys/bus/i2c/devices/0-00xx/eeprom1.
2. Confirmed it shows the correct hardware data when a module is present.
3. Verified the information is successfully erased (flushed) immediately after the module is plugged out, proving that the cache cleanup is working perfectly.
