### PR TITLE
[watchdog] Fix watchdogutil and sonic_platform errors for ES1227

### DIFF
--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/chassis.py
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/chassis.py
@@ -19,6 +19,7 @@ try:
     from sonic_platform.sfp import Sfp
     from sonic_platform.eeprom import Tlv
     from sonic_platform.fan_drawer import FanDrawer
+    from sonic_py_common import logger
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -41,6 +42,8 @@ GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
 GET_PLATFORM_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.platform"
 GET_HOST_HWSKU_CMD = 'grep ^onie_machine= /host/machine.conf | cut -f2 -d"="'
 GET_HOST_PLATFORM_CMD = 'grep ^onie_platform /host/machine.conf | cut -f2 -d"="'
+
+sonic_logger = logger.Logger()
 
 class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
@@ -309,7 +312,7 @@ class Chassis(ChassisBase):
         try:
             if self._watchdog is None:
                 from sonic_platform.watchdog import WatchdogImplBase
-                watchdog_device = "watchdog1"
+                watchdog_device = "watchdog0"
                 self._watchdog = WatchdogImplBase(watchdog_device)
         except Exception as e:
             sonic_logger.log_warning(" Fail to load watchdog {}".format(repr(e)))

--- a/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/watchdog.py
+++ b/platform/marvell-prestera/sonic-platform-wistron/es1227_54ts_p2/sonic_platform/watchdog.py
@@ -118,6 +118,8 @@ class WatchdogImplBase(WatchdogBase):
 
         timeout_path = self.watchdog_sysfs_path + "timeout"
         timeout = self.__read_txt_file(timeout_path)
+        if timeout is None:
+            return None
         return int(timeout)
 
     def _gettimeleft(self):
@@ -128,6 +130,8 @@ class WatchdogImplBase(WatchdogBase):
 
         timeleft_path = self.watchdog_sysfs_path + "timeleft"
         timeleft = self.__read_txt_file(timeleft_path)
+        if timeleft is None:
+            return None
         return int(timeleft)
 
 


### PR DESCRIPTION
# Fix multiple Python errors in sonic_platform and watchdogutil that caused the es1227_54ts_p2-watchdog.service to fail and trigger system instability. Summary of changes:
1. Fix NameError in chassis.py: Define 'sonic_logger' before use in get_watchdog().
2. Fix TypeError in watchdog.py: Handle NoneType return from __read_txt_file() before converting to int in _gettimeout() and _gettimeleft().
3. Correct watchdog device: Update hardcoded 'watchdog1' to 'watchdog0' to match the actual character device present on the SBSA Generic Watchdog. 
# Error logs observed in syslog
Apr 10 09:40:10.432090 sonic INFO sh[6410]: Traceback (most recent call last):
Apr 10 09:40:10.432228 sonic INFO sh[6410]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform/chassis.py", line 313, in get_watchdog
Apr 10 09:40:10.432305 sonic INFO sh[6410]:     self._watchdog = WatchdogImplBase(watchdog_device)
Apr 10 09:40:10.432368 sonic INFO sh[6410]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform/watchdog.py", line 61, in __init__
Apr 10 09:40:10.432604 sonic INFO sh[6410]:     self.timeout = self._gettimeout()
                                               ^^^^^^^^^^^^^^^^^^
Apr 10 09:40:10.432772 sonic INFO sh[6410]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform/watchdog.py", line 121, in _gettimeout
Apr 10 09:40:10.432834 sonic INFO sh[6410]:     return int(timeout)
                                               ^^^^^^^^^^^^
Apr 10 09:40:10.432958 sonic INFO sh[6410]: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
...
Apr 10 09:40:10.437331 sonic INFO sh[6410]: NameError: name 'sonic_logger' is not defined
