### PR TITLE
[monit] Fix monit.sock connection error

### DIFF
--- a/wistron_patches/0010-fix-monit-error.patch
+++ b/wistron_patches/0010-fix-monit-error.patch
@@ -1,0 +1,23 @@
+diff --git a/files/image_config/monit/monitrc b/files/image_config/monit/monitrc
+index e3b252fce..1967dd831 100644
+--- a/files/image_config/monit/monitrc
++++ b/files/image_config/monit/monitrc
+@@ -17,7 +17,7 @@
+ ## Start Monit in the background (run as a daemon):
+ #
+   set daemon 60             # check services at 1-minute intervals
+-    with start delay 300    # we delay Monit to start monitoring for 5 minutes
++    with start delay 0    # we delay Monit to start monitoring for 5 minutes
+                             # intentionally such that all containers and processes
+                             # have ample time to start up.
+ #
+diff --git a/src/sonic-eventd/tools/monit_events b/src/sonic-eventd/tools/monit_events
+index ebb9acce4..66d90a9a2 100644
+--- a/src/sonic-eventd/tools/monit_events
++++ b/src/sonic-eventd/tools/monit_events
+@@ -3,4 +3,4 @@
+ ###############################################################################
+ check program container_eventd with path "/usr/bin/events_monit_test.py"
+     every 5 cycles
+-    if status != 0 for 3 cycle then alert repeat every 1 cycles
++    if status != 0 for 5 cycles then alert repeat every 1 cycles


### PR DESCRIPTION
Problem:
The global 'with start delay 300' in monitrc prevented the creation of /var/run/monit.sock for 5 minutes after boot. This caused any monit-related commands (e.g., monit status, monit reload) to fail with "No such file or directory" during the early boot phase.

Solution:
1. Removed the global 'with start delay 300' (set value to zero) from monitrc to ensure the Unix socket is created immediately when the monit daemon starts.
2. Implemented per-service grace periods by adjusting individual monit configs to use cycle-based thresholds (e.g., 'for 5 cycles'). Boot-up Sequence and Cycle Analysis on DUT (Why 5 cycles) : Assuming monit checks every 60 seconds (1 cycle):
- 13:40:18: Monit daemon started (Socket created).
- Check 1 (approx. 13:41:18): Failed (eventd container/service not yet ready).
- Check 2 (approx. 13:42:18): Borderline (services starting up).
- Check 3 (approx. 13:43:18): Success (services fully ready). Conclusion on Threshold Settings:
- Using 'for 3 cycles': Failures are reported around 13:43. This is on the edge of readiness. A slightly slower boot could trigger a false alarm before the service recovers a few seconds later.
- Using 'for 5 cycles': Failures are reported around 13:45. This provides a safe buffer that filters out all boot-up transients, ensuring that only genuine service failures trigger an alert.
