### PR TITLE
[ORCHAGENT] fix: add patch to ignore wistron custom poe/dhcp fields

### DIFF
--- a/wistron_patches/0010-ignore-wistron-custom-port-fields.patch
+++ b/wistron_patches/0010-ignore-wistron-custom-port-fields.patch
@@ -1,0 +1,17 @@
+diff --git a/src/sonic-swss/orchagent/port/porthlpr.cpp b/src/sonic-swss/orchagent/port/porthlpr.cpp
+index 2d7c552b..447cc43f 100644
+--- a/src/sonic-swss/orchagent/port/porthlpr.cpp
++++ b/src/sonic-swss/orchagent/port/porthlpr.cpp
+@@ -1272,6 +1272,12 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
+              * Setting exists in sonic-port.yang with possible values: routed|access|trunk
+              */
+         }
++        else if (field == "poe_pri" || field == "poe_status" || field == "poe_maxpower" || field == "poe_tlv" || field == "dhcp_rate_limit")
++        {
++            /* Placeholder to prevent warning for Wistron custom PoE and DHCP fields.
++             * These fields are actively managed by pmon/poemd instead of Orchagent.
++             */
++        }
+         else
+         {
+             SWSS_LOG_WARN("Unknown field(%s): skipping ...", field.c_str());


### PR DESCRIPTION
[Root Cause]
The Orchagent daemon parses the ConfigDB PORT table using a strict attribute whitelist. The ES1227-54TS-P2 platform defines custom hardware-specific properties (e.g., poe_pri, poe_status, poe_maxpower, poe_tlv, dhcp_rate_limit) in port_config.ini for power management and security. Since these are not native SONiC attributes, Orchagent generates massive false-positive 'Unknown field: skipping' warnings mapping to every port, severely polluting the syslog. 

[Resolution]
Introduced 0010-ignore-wistron-custom-port-fields.patch which injects placeholders inside PortHelper::parsePortConfig() to silently acknowledge and skip these Wistron-specific parameters. These configurations are fundamentally managed by dedicated platform daemons (e.g., pmon, poe_cfg_init.py via poetool) and do not fall under Orchagent's SAI jurisdiction. This KISS-driven patch strictly serves as a log noise suppression mechanism. 

[Impact]
- Completely resolves GUI/syslog pollution (>100 false warnings per boot).
- Zero impact on SAI and PoE PHY initialization logic."

