### PR TITLE
[YANG]: add PoE leaf nodes to sonic-port.yang for Wistron PoE platform

### DIFF
--- a/wistron_patches/0012-sonic-port-yang-add-poe-fields.patch
+++ b/wistron_patches/0012-sonic-port-yang-add-poe-fields.patch
@@ -1,0 +1,78 @@
+diff --git a/src/sonic-yang-models/yang-models/sonic-port.yang b/src/sonic-yang-models/yang-models/sonic-port.yang
+index fb71247fe..0ab64e5ec 100644
+--- a/src/sonic-yang-models/yang-models/sonic-port.yang
++++ b/src/sonic-yang-models/yang-models/sonic-port.yang
+@@ -241,6 +241,34 @@ module sonic-port{
+ 						type int32;
+ 				}
+ 
++				leaf poe_maxpower {
++					description "PoE max power limit for the port";
++					type string {
++						length 0..64;
++					}
++				}
++
++				leaf poe_pri {
++					description "PoE priority for the port";
++					type string {
++						length 0..64;
++					}
++				}
++
++				leaf poe_status {
++					description "PoE status for the port";
++					type string {
++						length 0..64;
++					}
++				}
++
++				leaf poe_tlv {
++					description "PoE TLV status for the port";
++					type string {
++						length 0..64;
++					}
++				}
++
+ 			} /* end of list PORT_LIST */
+ 
+ 		} /* end of container PORT */
+diff --git a/src/sonic-yang-models/cvlyang-models/sonic-port.yang b/src/sonic-yang-models/cvlyang-models/sonic-port.yang
+index fb71247fe..0ab64e5ec 100644
+--- a/src/sonic-yang-models/cvlyang-models/sonic-port.yang
++++ b/src/sonic-yang-models/cvlyang-models/sonic-port.yang
+@@ -241,6 +241,34 @@ module sonic-port{
+ 						type int32;
+ 				}
+ 
++				leaf poe_maxpower {
++					description "PoE max power limit for the port";
++					type string {
++						length 0..64;
++					}
++				}
++
++				leaf poe_pri {
++					description "PoE priority for the port";
++					type string {
++						length 0..64;
++					}
++				}
++
++				leaf poe_status {
++					description "PoE status for the port";
++					type string {
++						length 0..64;
++					}
++				}
++
++				leaf poe_tlv {
++					description "PoE TLV status for the port";
++					type string {
++						length 0..64;
++					}
++				}
++
+ 			} /* end of list PORT_LIST */
+ 
+ 		} /* end of container PORT */


### PR DESCRIPTION
This patch resolves the "All Keys are not parsed in PORT" validation error caused by the missing PoE fields in the PORT table schema on PoE-capable platforms. Fixed test outputs (failed due to missing 'poe_maxpower' in YANG):
  - platform_tests/api/test_component/TestComponentApi/test_get_status.out
  - platform_tests/api/test_component/TestComponentApi/test_update_firmware.out
  - platform_tests/fwutil/test_fwutil/test_fwutil_install_bad_name.out Changes:
  - Add four optional leaf nodes (poe_maxpower, poe_pri, poe_status, poe_tlv) to PORT_LIST in both:
      - src/sonic-yang-models/yang-models/sonic-port.yang
      - src/sonic-yang-models/cvlyang-models/sonic-port.yang
  - Generated patch file: wistron_patches/0012-sonic-port-yang-add-poe-fields.patch error log :
E           Failed: pre-test YANG validation failed:
E           lab-kyoto-54p: Failed to apply patch due to: Validate json patch: [] failed due to:Data Loading Failed
E           All Keys are not parsed in PORT
E           dict_keys(['Ethernet0', 'Ethernet1', 'Ethernet10', 'Ethernet11', 'Ethernet12', 'Ethernet13', 'Ethernet14', 'Ethernet15', 'Ethernet16', 'Ethernet17', 'Ethernet18', 'Ethernet19', 'Ethernet2', 'Ethernet20', 'Ethernet21', 'Ethernet22', 'Ethernet23', 'Ethernet24', 'Ethernet25', 'Ethernet26', 'Ethernet27', 'Ethernet28', 'Ethernet29', 'Ethernet3', 'Ethernet30', 'Ethernet31', 'Ethernet32', 'Ethernet33', 'Ethernet34', 'Ethernet35', 'Ethernet36', 'Ethernet37', 'Ethernet38', 'Ethernet39', 'Ethernet4', 'Ethernet40', 'Ethernet41', 'Ethernet42', 'Ethernet43', 'Ethernet44', 'Ethernet45', 'Ethernet46', 'Ethernet47', 'Ethernet48', 'Ethernet49', 'Ethernet5', 'Ethernet50', 'Ethernet51', 'Ethernet52', 'Ethernet53', 'Ethernet6', 'Ethernet7', 'Ethernet8', 'Ethernet9'])
E           exceptionList:["'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'"]
E           Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
E           Try "config apply-patch -h" for help.
E
E           Error: Validate json patch: [] failed due to:Data Loading Failed
E           All Keys are not parsed in PORT
E           dict_keys(['Ethernet0', 'Ethernet1', 'Ethernet10', 'Ethernet11', 'Ethernet12', 'Ethernet13', 'Ethernet14', 'Ethernet15', 'Ethernet16', 'Ethernet17', 'Ethernet18', 'Ethernet19', 'Ethernet2', 'Ethernet20', 'Ethernet21', 'Ethernet22', 'Ethernet23', 'Ethernet24', 'Ethernet25', 'Ethernet26', 'Ethernet27', 'Ethernet28', 'Ethernet29', 'Ethernet3', 'Ethernet30', 'Ethernet31', 'Ethernet32', 'Ethernet33', 'Ethernet34', 'Ethernet35', 'Ethernet36', 'Ethernet37', 'Ethernet38', 'Ethernet39', 'Ethernet4', 'Ethernet40', 'Ethernet41', 'Ethernet42', 'Ethernet43', 'Ethernet44', 'Ethernet45', 'Ethernet46', 'Ethernet47', 'Ethernet48', 'Ethernet49', 'Ethernet5', 'Ethernet50', 'Ethernet51', 'Ethernet52', 'Ethernet53', 'Ethernet6', 'Ethernet7', 'Ethernet8', 'Ethernet9'])
E           exceptionList:["'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'", "'poe_maxpower'"]