### PR TITLE
Fix reboot cause bit mappings

### DIFF
--- a/platform/marvell-teralynx/sonic-platform-modules-wistron/6512-32r/utils/6512-reboot-check
+++ b/platform/marvell-teralynx/sonic-platform-modules-wistron/6512-32r/utils/6512-reboot-check
@@ -44,24 +44,24 @@ WATCHDOG_REBOOT_CHECK()
         if [[ $reboot_cause -ne 0x00 ]]; then
                 reboot_cause=$((~reboot_cause & 0xFF))
                 echo "[hardware reboot-cause] : ${reboot_cause}"
-		if [[ $((reboot_cause & 0x80)) -ne 0 ]]; then
+                if [[ $((reboot_cause & 0x80)) -ne 0 ]]; then
                         reboot_reason=$REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER
                 elif [[ $((reboot_cause & 0x40)) -ne 0 ]]; then
                         reboot_reason=$REBOOT_CAUSE_INSUFFICIENT_FAN_SPEED
-                elif [[ $((reboot_cause & 0x20)) -ne 0 ]]; then
-                        reboot_reason=$REBOOT_CAUSE_HARDWARE_CPU
                 elif [[ $((reboot_cause & 0x10)) -ne 0 ]]; then
-                        reboot_reason=$REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC
+                        reboot_reason=$REBOOT_CAUSE_WATCHDOG
+                elif [[ $((reboot_cause & 0x20)) -ne 0 ]]; then
+                        reboot_reason=$CPU_PLATFORM_RESET
                 elif [[ $((reboot_cause & 0x08)) -ne 0 ]]; then
                         reboot_reason=$REBOOT_CAUSE_HARDWARE_BUTTON
                 elif [[ $((reboot_cause & 0x04)) -ne 0 ]]; then
-                        reboot_reason=$REBOOT_CAUSE_WATCHDOG
+                        reboot_reason=$REBOOT_CAUSE_HARDWARE_CPU
                 elif [[ $((reboot_cause & 0x02)) -ne 0 ]]; then
                         reboot_reason=$REBOOT_CAUSE_POWER_LOSS
                 elif [[ $((reboot_cause & 0x01)) -ne 0 ]]; then
-                        reboot_reason=$REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC
-                fi	
-		echo "reboot_reason: $reboot_reason"
+                        reboot_reason=$REBOOT_CAUSE_HARDWARE_OTHER
+                fi
+                echo "reboot_reason: $reboot_reason"
                 echo "$reboot_reason" > $REBOOT_CAUSE_FILE
                 log=$(cat ${REBOOT_CAUSE_FILE})
                 echo "[reboot-cause.txt] : $log"
@@ -71,4 +71,3 @@ WATCHDOG_REBOOT_CHECK()
 }
 
 WATCHDOG_REBOOT_CHECK
-


### PR DESCRIPTION
#### Why I did it

Correct the Wistron 6512-32r reboot cause bit mapping used by `6512-reboot-check`.

#### How I did it

Updated the reboot cause mapping in:

- `platform/marvell-teralynx/sonic-platform-modules-wistron/6512-32r/utils/6512-reboot-check`

Mapping changes:

- `0x20`: changed from `$REBOOT_CAUSE_HARDWARE_CPU` to `$CPU_PLATFORM_RESET`
- `0x10`: changed from `$REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC` to `$REBOOT_CAUSE_WATCHDOG`
- `0x04`: changed from `$REBOOT_CAUSE_WATCHDOG` to `$REBOOT_CAUSE_HARDWARE_CPU`
- `0x01`: changed from `$REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC` to `$REBOOT_CAUSE_HARDWARE_OTHER`

#### How to verify it

Verify on Wistron 6512-32r hardware:

- Trigger or simulate each reboot cause bit and confirm `/host/reboot-cause/reboot-cause.txt` reports the expected reason.
- Confirm watchdog reset reports `$REBOOT_CAUSE_WATCHDOG`.
- Confirm CPU/platform reset reports `$CPU_PLATFORM_RESET`.
- Confirm hardware CPU reset reports `$REBOOT_CAUSE_HARDWARE_CPU`.
- Confirm hardware other reset reports `$REBOOT_CAUSE_HARDWARE_OTHER`.